### PR TITLE
[Fixit Q4 2022] Bump cdap version and hadoop-common

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,9 +30,9 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <avro.version>1.7.7</avro.version>
     <spark.version>1.6.1</spark.version>
-    <cdap.version>6.1.0-SNAPSHOT</cdap.version>
+    <cdap.version>6.8.0</cdap.version>
     <hydrator.version>2.2.0</hydrator.version>
-    <hadoop.version>2.4.0</hadoop.version>
+    <hadoop.version>2.10.2</hadoop.version>
     <parquet-avro.version>1.9.0</parquet-avro.version>
     <commons-jexl.version>3.0</commons-jexl.version>
     <commons-lang.version>3.5</commons-lang.version>
@@ -112,7 +112,7 @@
     </dependency>
     <dependency>
       <groupId>io.cdap.cdap</groupId>
-      <artifactId>cdap-data-pipeline</artifactId>
+      <artifactId>cdap-data-pipeline2_2.11</artifactId>
       <version>${cdap.version}</version>
       <scope>test</scope>
     </dependency>
@@ -299,8 +299,8 @@
           <version>1.1.0</version>
           <configuration>
             <cdapArtifacts>
-              <parent>system:cdap-data-pipeline[6.1.0-SNAPSHOT,7.0.0-SNAPSHOT)</parent>
-              <parent>system:cdap-data-streams[6.1.0-SNAPSHOT,7.0.0-SNAPSHOT)</parent>
+              <parent>system:cdap-data-pipeline[6.8.0,7.0.0-SNAPSHOT)</parent>
+              <parent>system:cdap-data-streams[6.8.0,7.0.0-SNAPSHOT)</parent>
             </cdapArtifacts>
           </configuration>
           <executions>


### PR DESCRIPTION
Successfully builds, `mvn test` output:
<img width="486" alt="Screen Shot 2022-12-06 at 10 22 56 AM" src="https://user-images.githubusercontent.com/114443254/205991352-3b27a8a1-1ad0-4020-8348-d4953a019a30.png">
