### PR TITLE
[Fixit Q4 2022] Exclude log4j

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,6 +126,12 @@
       <artifactId>hydrator-test</artifactId>
       <version>${cdap.version}</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.avro</groupId>


### PR DESCRIPTION
It wasn't indirectly used in the first place, but we should exclude it anyways.

Indirect dependency on log4j is no longer in the dependency tree:
<img width="355" alt="1" src="https://user-images.githubusercontent.com/114443254/208214707-6010561d-ff87-452d-aec9-9e77fcbeef7e.png">

Unit tests still pass:
<img width="397" alt="2" src="https://user-images.githubusercontent.com/114443254/208214714-84e00b42-9101-4d13-b2b6-c46d4f673a2a.png">
